### PR TITLE
Fix make error unknown type name 'yyscan_t'

### DIFF
--- a/json_parser.y
+++ b/json_parser.y
@@ -27,8 +27,8 @@ extern void yyerror(yyscan_t, const char *);
 %defines
 %error-verbose
 %pure-parser
-%parse-param {yyscan_t scanner}
-%lex-param {yyscan_t scanner}
+%parse-param {void *scanner}
+%lex-param {void *scanner}
 
 %token TSTRING
 %token TNUMBER


### PR DESCRIPTION
Address make error described in issue #5

```
# make
bison json_parser.y
flex json_scanner.l
gcc -Wall main.c json_parser.tab.c json_scanner.yy.c -o jsonval
In file included from main.c:23:0:
json_parser.tab.h:65:14: error: unknown type name ‘yyscan_t’
 int yyparse (yyscan_t scanner);
              ^
In file included from json_parser.y:21:0:
json_parser.tab.h:65:14: error: unknown type name ‘yyscan_t’
 int yyparse (yyscan_t scanner);
              ^
json_scanner.yy.c:1295:16: warning: ‘input’ defined but not used [-Wunused-function]
     static int input  (yyscan_t yyscanner)
                ^
Makefile:4: recipe for target 'all' failed
make: *** [all] Error 1
```
